### PR TITLE
Fix makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ notes
 README.md
 ttf-demo/
 SDL2_ttf-2.0.15/
+build-and-run
+test.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-CFLAGS=-g -O2 -Wall $(shell sdl2-config --cflags)
-LDFLAGS=-g -O2 -Wall $(shell sdl2-config --libs) -lSDL2_ttf
+CFLAGS=-g -O3 -Wall $(shell sdl2-config --cflags)
+LDLIBS=$(shell sdl2-config --libs) -lSDL2_ttf
 
-PROGRAMS=$(basename $(wildcard *.c))
+TARGET=$(basename $(wildcard *.c))
 
-all: $(PROGRAMS)
+all: $(TARGET)
+
+clean: 
+	$(RM) $(TARGET)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ A minimal decision tree planning app
 * SDL2_ttf
 * make
 * gcc
+
+# Usage
+The application provides three modes of interaction with the decision tree- `Default`, `Edit`, and `Travel`.
+
+In Default Mode:
+ - `o` : make a child node for the current node
+ - `d` : delete the current node
+ - `h` : select the leftmost child of the current node
+ - `l` : select the rightmost child of the current node
+ - `k` : select the parent node of the current node
+ - `t` : enter travel mode
+ - `e` : enter edit mode
+ - `q` : quit the program
+
+In Edit Mode:
+ - type to enter text
+ - press `esc` to return to Default Mode
+
+In Travel Mode:
+ - press `esc` to return to Default Mode

--- a/dtree.c
+++ b/dtree.c
@@ -84,8 +84,8 @@ struct Node {
 	struct Node* p;
 	struct Array* children;
 	struct DoublePoint pos;
-    char* text;
-    int text_len;
+	char* text;
+	int text_len;
 };
 
 struct Graph {
@@ -204,10 +204,10 @@ void doKeyDown(SDL_KeyboardEvent *event) {
 void doKeyUp(SDL_KeyboardEvent *event) {
 	if (event->repeat == 0) {
 		if ( graph.mode != Edit ){
-            if (event->keysym.sym == SDLK_o) {
+			if (event->keysym.sym == SDLK_o) {
 				makeChild(graph.selected);
 			}
-            if (event->keysym.sym == SDLK_d) {
+			if (event->keysym.sym == SDLK_d) {
 				removeNodeFromGraph(graph.selected);
 			}
 			if (event->keysym.sym == SDLK_h) {
@@ -425,7 +425,7 @@ void renderMessage(char* message, Point pos, double width, double height){
 	// create surface from string
 	SDL_Surface* surfaceMessage =
 		TTF_RenderText_Solid(FONT, message, color);
-	//                                                       ^ wrapped len
+	//      ^ wrapped len
 
 	// now you can convert it into a texture
 	SDL_Texture* Message = SDL_CreateTextureFromSurface(app.renderer, surfaceMessage);
@@ -601,7 +601,7 @@ void deleteNode(Node* node){
 	if ( node == NULL ) {
 		return;
 	}
-    /* delete each child */
+	/* delete each child */
 	for (int i=0; i<node->children->num; i++){
 		deleteNode( node->children->array[i] );
 	}
@@ -704,7 +704,7 @@ void readfile(const char* fname){
 		level = countTabs(ret);
 		/* create new child node */
 		hierarchy[level] = makeChild(hierarchy[level-1]);
-        /* copy current line to child node */
+		/* copy current line to child node */
 		strcpy(hierarchy[level]->text, ret + level);
 		hierarchy[level]->text_len = strlen(ret);
 	}
@@ -715,7 +715,7 @@ void readfile(const char* fname){
 
 int main(int argc, char *argv[]) {
 
-    const char* filename;
+	const char* filename;
 	/* set all bytes of App memory to zero */
 	memset(&app, 0, sizeof(App));
 
@@ -759,7 +759,7 @@ int main(int argc, char *argv[]) {
 	SDL_DestroyRenderer( app.renderer );
 	SDL_DestroyWindow( app.window );
 
-    //Quit SDL subsystems
-    SDL_Quit();
+	//Quit SDL subsystems
+	SDL_Quit();
 	return 0;
 }

--- a/dtree.c
+++ b/dtree.c
@@ -1,6 +1,7 @@
 // TODO
 // SDLK is software character, SCANCODE is hardware
 // - travel mode (debug prototype)
+// - add way to edit file name
 // - add, copy, paste functionality
 //
 // https://www.parallelrealities.co.uk/tutorials/#shooter
@@ -22,7 +23,7 @@
 #define SCREEN_WIDTH   1280
 #define SCREEN_HEIGHT  720
 
-/* static const char* TRAVEL_CHARS = "asdfghjl;"; */
+static const char* TRAVEL_CHARS = "asdfghjl;";
 
 // radius and thickness of node ring
 static int RADIUS = 50;
@@ -45,11 +46,14 @@ static int FONT_SIZE = 40;
 static int TEXTBOX_WIDTH_SCALE = 40;
 static int TEXTBOX_HEIGHT = 100;
 static int MAX_TEXT_LEN = 32;
-/* static int MAX_NUM_TRAVEL_CHARS = 2; */
+static int MAX_NUM_TRAVEL_CHARS = 2;
 
 static unsigned int BUF_SIZE = 128;
 
 enum Mode{Default, Edit, Travel};
+
+static SDL_Color EDIT_COLOR = {255, 255, 255};
+static SDL_Color TRAVEL_COLOR = {255, 0, 0};
 
 typedef struct Node Node;
 typedef struct Array Array;
@@ -86,7 +90,7 @@ struct Node {
 	struct DoublePoint pos;
 	char* text;
 	int text_len;
-	/* char* travel_text; */
+	char* travel_text;
 };
 
 struct Graph {
@@ -107,7 +111,7 @@ void eventHandler(SDL_Event *event);
 void set_pixel(SDL_Renderer *rend, int x, int y, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 void drawCircle(SDL_Renderer *surface, int n_cx, int n_cy, int radius, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 void drawRing(SDL_Renderer *surface, int n_cx, int n_cy, int radius, int thickness, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
-void renderMessage(char* message, Point pos, double width, double height);
+void renderMessage(char* message, Point pos, double width, double height, SDL_Color color);
 void presentScene();
 void prepareScene();
 Node* makeNode();
@@ -121,7 +125,7 @@ void writeChildrenStrings(FILE* file, Node* node, int level);
 void readfile(const char* filename);
 void deleteNode(Node* node);
 void removeNodeFromGraph(Node* node);
-/* void populateTravelText(Node* node); */
+void populateTravelText(Node* node);
 
 double clip(double num, double min, double max){
 	if ( num < min )
@@ -208,16 +212,10 @@ void doKeyDown(SDL_KeyboardEvent *event) {
 
 void doKeyUp(SDL_KeyboardEvent *event) {
 	if (event->repeat == 0) {
-		if ( graph.mode != Edit ){
+		if ( graph.mode == Default ){
 			if (event->keysym.sym == SDLK_o) {
 				makeChild(graph.selected);
 			}
-			/* if (event->keysym.sym == SDLK_t) { */
-				/* if ( graph.mode == Travel ) */
-					/* graph.mode = Default; */
-				/* else */
-					/* graph.mode = Travel; */
-			/* } */
 			if (event->keysym.sym == SDLK_d) {
 				removeNodeFromGraph(graph.selected);
 			}
@@ -234,19 +232,23 @@ void doKeyUp(SDL_KeyboardEvent *event) {
 			if (event->keysym.sym == SDLK_k) {
 				graph.selected = graph.selected->p;
 			}
-
-			/* if (event->keysym.sym == SDLK_t) { */
-			/*	graph.mode = Travel; */
-			/* } */
-
 		}
-
 		if (event->keysym.sym == SDLK_ESCAPE){
-			/* if ( graph.mode == Travel ) */
-			/*	graph.mode = Default; */
+			if ( graph.mode == Travel )
+				graph.mode = Default;
 			if ( graph.mode == Edit ){
 				graph.mode = Default;
 				SDL_StopTextInput();
+			}
+		}
+
+		if (event->keysym.sym == SDLK_t) {
+			if ( graph.mode != Travel ){
+				graph.mode = Travel;
+				populateTravelText(graph.selected);
+			}
+			else{
+				graph.mode = Default;
 			}
 		}
 
@@ -407,16 +409,16 @@ void drawNode(Node* node) {
 	message_pos.y = (int) ((node->pos.y) * app.window_size.y)  - (int)(TEXTBOX_HEIGHT / 2);
 
 	/* render node text */
-	renderMessage(node->text, message_pos, TEXTBOX_WIDTH_SCALE*node->text_len, TEXTBOX_HEIGHT);
+	renderMessage(node->text, message_pos, TEXTBOX_WIDTH_SCALE*node->text_len, TEXTBOX_HEIGHT, EDIT_COLOR);
 	/* render travel text */
-	/* if ( graph.mode == Travel ){ */
-	/* 	if (strlen(node->travel_text) > 0){ */
-	/* 		// position char in center of node */
-	/* 		message_pos.x = (int) ((node->pos.x) * app.window_size.x)  - (int)((TEXTBOX_WIDTH_SCALE) / 2); */
-	/* 		message_pos.y = (int) ((node->pos.y) * app.window_size.y)  - (int)(TEXTBOX_HEIGHT / 2); */
-	/* 		renderMessage(node->travel_text, message_pos, TEXTBOX_WIDTH_SCALE, TEXTBOX_HEIGHT); */
-	/* 	} */
-	/* } */
+	if ( graph.mode == Travel ){
+		if (strlen(node->travel_text) > 0){
+			// position char in center of node
+			message_pos.x = (int) ((node->pos.x) * app.window_size.x)  - (int)((TEXTBOX_WIDTH_SCALE) / 2) - RADIUS;
+			message_pos.y = (int) ((node->pos.y) * app.window_size.y)  - (int)(TEXTBOX_HEIGHT / 2) - RADIUS;
+			renderMessage(node->travel_text, message_pos, TEXTBOX_WIDTH_SCALE * 0.5, TEXTBOX_HEIGHT * 0.5, TRAVEL_COLOR);
+		}
+	}
 
 	/* draw edges between parent and child nodes */
 	if (node != graph.root){
@@ -433,11 +435,9 @@ void drawNode(Node* node) {
 }
 
 // testing SDL_TTF font rendering
-void renderMessage(char* message, Point pos, double width, double height){
+void renderMessage(char* message, Point pos, double width, double height, SDL_Color color){
 	if (!message)
 		return;
-
-	SDL_Color color = {255, 255, 255};
 
 	if ( DEBUG )
 		printf("rendering %s\n", message);
@@ -476,7 +476,7 @@ void update_pos_children(Node* node, double leftmost_bound, double rightmost_bou
 		printf("update node position to %lf %lf\n", node->pos.x, node->pos.y);
 
 	/* if ( node == graph.selected ) */
-	/* 	printf("selected: %lf %lf\n", leftmost_bound, rightmost_bound); */
+	/*	printf("selected: %lf %lf\n", leftmost_bound, rightmost_bound); */
 
 	/* dont update children if no children */
 	if ( node->children->num == 0)
@@ -608,7 +608,7 @@ Node* makeNode(){
 	node->pos.y = 0;
 	node->text = calloc(MAX_TEXT_LEN, sizeof(char));
 	node->text_len = 0;
-	/* node->travel_text = calloc(MAX_NUM_TRAVEL_CHARS, sizeof(char)); */
+	node->travel_text = calloc(MAX_NUM_TRAVEL_CHARS, sizeof(char));
 	return node;
 }
 
@@ -633,7 +633,7 @@ void deleteNode(Node* node){
 	/* Then delete node */
 	freeArray(node->children);
 	free(node->text);
-	/* free(node->travel_text); */
+	free(node->travel_text);
 	free(node);
 }
 
@@ -662,15 +662,14 @@ void makeGraph(){
 	graph.mode = Default;
 }
 
-/* void populateTravelText(Node* node){ */
-/*	node->p->travel_text[0] = 'k'; */
-/*	if ( node->children->num > strlen(TRAVEL_CHARS) ) */
-/*		return; */
-/*	for (int i = 0; i < node->children->num; ++i) { */
-/*		node->children->array[i]->travel_text[0] = TRAVEL_CHARS[i]; */
-/*	} */
-
-/* } */
+void populateTravelText(Node* node){
+	node->p->travel_text[0] = 'k';
+	if ( node->children->num > strlen(TRAVEL_CHARS) )
+		return;
+	for (int i = 0; i < node->children->num; ++i) {
+		node->children->array[i]->travel_text[0] = TRAVEL_CHARS[i];
+	}
+}
 
 /* Recursively print children of nodes, with each child indented once from the parent */
 void writeChildrenStrings(FILE* file, Node* node, int level){

--- a/dtree.c
+++ b/dtree.c
@@ -174,7 +174,7 @@ void initSDL() {
 	atexit(TTF_Quit); /* remember to quit SDL_ttf */
 
 	//this opens a font style and sets a size
-	FONT = TTF_OpenFont("/home/jack/drive/cs2/dtree/assets/FiraSans-Regular.ttf", FONT_SIZE);
+	FONT = TTF_OpenFont("./assets/FiraSans-Regular.ttf", FONT_SIZE);
 
 	printf("TTF_FontHeight          : %d\n",TTF_FontHeight(FONT));
 	printf("TTF_FontAscent          : %d\n",TTF_FontAscent(FONT));

--- a/dtree.c
+++ b/dtree.c
@@ -1,7 +1,9 @@
 // TODO
 // SDLK is software character, SCANCODE is hardware
-// - travel mode (debug prototype)
-// - add way to edit file name
+// - travel mode (better population of text)
+// 	- issue: travel_text is freed already before it gets cleared
+// - make parent visible
+// - add way to edit file name in app
 // - add, copy, paste functionality
 //
 // https://www.parallelrealities.co.uk/tutorials/#shooter
@@ -23,44 +25,15 @@
 #define SCREEN_WIDTH   1280
 #define SCREEN_HEIGHT  720
 
-static const char* TRAVEL_CHARS = "asdfghjl;";
-
-// radius and thickness of node ring
-static int RADIUS = 50;
-static int THICKNESS = 10;
-
-static double LEFT_BOUNDARY = 0.2;
-static double RIGHT_BOUNDARY = 0.8;
-
-// Spacing between layers of tree
-static double LAYER_MARGIN = 0.3;
-// Spacing between edge of screen and node
-static double SIDE_MARGIN = 0.2;
-
-static double SCALE = 1.5;
-
-static TTF_Font* FONT;
-static int FONT_SIZE = 40;
-
-// width and heigh of text boxes
-static int TEXTBOX_WIDTH_SCALE = 40;
-static int TEXTBOX_HEIGHT = 100;
-static int MAX_TEXT_LEN = 32;
-static int MAX_NUM_TRAVEL_CHARS = 2;
-
-static unsigned int BUF_SIZE = 128;
-
-enum Mode{Default, Edit, Travel};
-
-static SDL_Color EDIT_COLOR = {255, 255, 255};
-static SDL_Color TRAVEL_COLOR = {255, 0, 0};
-
 typedef struct Node Node;
 typedef struct Array Array;
 typedef struct Graph Graph;
 typedef struct Point Point;
 typedef struct DoublePoint DoublePoint;
 typedef struct App App;
+
+enum Mode{Default, Edit, Travel};
+
 struct Point {
 	int x;
 	int y;
@@ -103,6 +76,39 @@ struct Graph {
 static App app;
 static Graph graph;
 
+static const char* TRAVEL_CHARS = "asdfghjl;";
+// radius and thickness of node ring
+static int RADIUS = 50;
+static int THICKNESS = 10;
+// Boundaries for tree
+static double LEFT_BOUNDARY = 0.2;
+static double RIGHT_BOUNDARY = 0.8;
+// Spacing between layers of tree
+static double LAYER_MARGIN = 0.3;
+// Spacing between edge of screen and node
+static double SIDE_MARGIN = 0.2;
+static double SCALE = 1.5;
+// Default Font
+static TTF_Font* FONT;
+static int FONT_SIZE = 40;
+// width and heigh of text boxes
+static int TEXTBOX_WIDTH_SCALE = 40;
+static int TEXTBOX_HEIGHT = 100;
+static int MAX_TEXT_LEN = 32;
+// number of characters for travel hint text
+static int MAX_NUM_TRAVEL_CHARS = 2;
+// current idx of travel char
+static int TRAVEL_CHAR_I = 0;
+// array of all nodes to be traveled to
+static Node** TRAVEL_NODES;
+// length of TRAVEL_NODES
+static int NUM_TRAVEL_NODES;
+// buffer to store current travel hint progress
+static char* TRAVEL_CHAR_BUF;
+static unsigned int BUF_SIZE = 128;
+static SDL_Color EDIT_COLOR = {255, 255, 255};
+static SDL_Color TRAVEL_COLOR = {255, 0, 0};
+
 double clip(double num, double min, double max);
 void initSDL();
 void doKeyDown(SDL_KeyboardEvent *event);
@@ -125,6 +131,7 @@ void writeChildrenStrings(FILE* file, Node* node, int level);
 void readfile(const char* filename);
 void deleteNode(Node* node);
 void removeNodeFromGraph(Node* node);
+void clearTravelText();
 void populateTravelText(Node* node);
 
 double clip(double num, double min, double max){
@@ -202,6 +209,21 @@ void initSDL() {
 	}
 }
 
+void switch2Default(){
+	printf("switching to default\n");
+	if ( graph.mode == Travel ){
+		free (TRAVEL_NODES);
+		TRAVEL_NODES = NULL;
+		NUM_TRAVEL_NODES = 0;
+		TRAVEL_CHAR_I = 0;
+
+		if ( TRAVEL_CHAR_BUF ) free(TRAVEL_CHAR_BUF);
+		TRAVEL_CHAR_BUF = calloc(MAX_NUM_TRAVEL_CHARS, sizeof(char));
+	}
+	graph.mode = Default;
+	printf("switched to default %p\n", TRAVEL_NODES);
+}
+
 void doKeyDown(SDL_KeyboardEvent *event) {
 	if (event->repeat == 0) {
 		if (event->keysym.sym == SDLK_q) {
@@ -234,21 +256,18 @@ void doKeyUp(SDL_KeyboardEvent *event) {
 			}
 		}
 		if (event->keysym.sym == SDLK_ESCAPE){
-			if ( graph.mode == Travel )
-				graph.mode = Default;
-			if ( graph.mode == Edit ){
-				graph.mode = Default;
-				SDL_StopTextInput();
-			}
+			switch2Default();
 		}
 
 		if (event->keysym.sym == SDLK_t) {
-			if ( graph.mode != Travel ){
+			if ( graph.mode == Edit ){}
+			else if ( graph.mode != Travel ){
 				graph.mode = Travel;
 				populateTravelText(graph.selected);
+				printf("end\n");
 			}
 			else{
-				graph.mode = Default;
+				switch2Default();
 			}
 		}
 
@@ -261,8 +280,6 @@ void doKeyUp(SDL_KeyboardEvent *event) {
 		if (event->keysym.sym == SDLK_e){
 			if ( graph.mode != Edit ){
 				graph.mode = Edit;
-				printf("SDL_StartTextInput()\n");
-				SDL_StartTextInput();
 			}
 		}
 		if (event->keysym.sym == SDLK_MINUS){
@@ -292,6 +309,28 @@ void eventHandler(SDL_Event *event) {
 			}
 			if (graph.mode == Travel){
 				// go to node specified by travel chars
+				printf("handling travel input: %d/%d\n", TRAVEL_CHAR_I, MAX_NUM_TRAVEL_CHARS);
+				if ( TRAVEL_CHAR_I < MAX_NUM_TRAVEL_CHARS ) {
+					TRAVEL_CHAR_BUF[TRAVEL_CHAR_I++] = event->edit.text[0];
+					// check if any nodes travel text matches current input
+					for (int i = 0; i < NUM_TRAVEL_NODES; ++i) {
+						if ( strcmp(TRAVEL_CHAR_BUF, TRAVEL_NODES[i]->travel_text) == 0 ){
+							graph.selected = TRAVEL_NODES[i];
+							// reset travel text
+							printf("freeing travel chars\n");
+							if ( TRAVEL_CHAR_BUF ) free(TRAVEL_CHAR_BUF);
+							printf("freed travel chars\n");
+							TRAVEL_CHAR_BUF = calloc(MAX_NUM_TRAVEL_CHARS, sizeof(char));
+							TRAVEL_CHAR_I = 0;
+							populateTravelText(graph.selected);
+							printf("changing nodes\n");
+						}
+
+					}
+				}
+				printf("handled travel input\n");
+
+
 			}
 			break;
 
@@ -501,17 +540,20 @@ void update_pos_children(Node* node, double leftmost_bound, double rightmost_bou
 
 void compute_root_bounds_from_selected_and_update_pos_children(Node* node, double leftmost_bound, double rightmost_bound, double level){
 
+	printf("crb start\n");
 	/* If we reached the root, compute all child bounds relative to the root bounds */
 	if (node == graph.root){
 		update_pos_children(node, leftmost_bound, rightmost_bound, level);
 		return;
 	}
+	printf("root not reached\n");
 
 	/* we step through each sibling of the current node,
 	giving each child the same size as the current node */
 	double step_size = rightmost_bound - leftmost_bound;
 	int child_idx = 0;
 
+	printf("computing node children\n");
 	/* compute idx of child relative to parent */
 	for (int i = 0; i < node->p->children->num; i++) {
 		if (node->p->children->array[i] == node){
@@ -519,11 +561,13 @@ void compute_root_bounds_from_selected_and_update_pos_children(Node* node, doubl
 			break;
 		}
 	}
+	printf("computed node children\n");
 	/* compute the left and right boundaries of the parent node relative
 	to the location of the child */
 	double parent_left_bound = leftmost_bound - (step_size * child_idx);
 	double parent_right_bound = rightmost_bound + (step_size * (node->p->children->num - child_idx-1));
 	compute_root_bounds_from_selected_and_update_pos_children(node->p, parent_left_bound, parent_right_bound, level - LAYER_MARGIN);
+	printf("crb end\n");
 }
 
 /* Debug function, used to print locations of all nodes in indented hierarchy */
@@ -662,13 +706,50 @@ void makeGraph(){
 	graph.mode = Default;
 }
 
-void populateTravelText(Node* node){
-	node->p->travel_text[0] = 'k';
-	if ( node->children->num > strlen(TRAVEL_CHARS) )
+
+void clearTravelText() {
+	printf("start clearTravelText()\n");
+	// return if already freed
+	if ( TRAVEL_NODES == NULL || NUM_TRAVEL_NODES == 0 )
 		return;
+	printf("travel nodes %p, num %d\n", TRAVEL_NODES, NUM_TRAVEL_NODES);
+	// Clear all travel text in each travel node
+	for (int i = 0; i < NUM_TRAVEL_NODES; ++i) {
+		for (int j = 0; j < MAX_NUM_TRAVEL_CHARS; j++) {
+			printf("node %d (%p)\n", i, TRAVEL_NODES[i]);
+			printf("travel_text %p\n", TRAVEL_NODES[i]->travel_text);
+			if (TRAVEL_NODES[i]->travel_text)
+				TRAVEL_NODES[i]->travel_text[j] = '\0';
+			printf("accessed travel text\n");
+		}
+	}
+	// Clear travel node array
+	printf("freeing TRAVEL_NODES\n");
+	if ( TRAVEL_NODES )
+		free ( TRAVEL_NODES );
+	TRAVEL_NODES = NULL;
+	NUM_TRAVEL_NODES = 0;
+	printf("end clearTravelText()\n");
+}
+
+void populateTravelText(Node* node){
+	printf("populate start\n");
+	clearTravelText();
+	node->p->travel_text[0] = 'k';
+	// cancel if too many children
+	if ( node->children->num > strlen(TRAVEL_CHARS) ){
+		TRAVEL_NODES = NULL;
+		return;
+	}
+	NUM_TRAVEL_NODES = node->children->num + 1;
+	TRAVEL_NODES = (Node**) calloc(NUM_TRAVEL_NODES, sizeof(Node**));
+	TRAVEL_NODES[0] = node->p;
 	for (int i = 0; i < node->children->num; ++i) {
 		node->children->array[i]->travel_text[0] = TRAVEL_CHARS[i];
+		printf("travel txt: %p\n", node->children->array[i]->travel_text);
+		TRAVEL_NODES[i+1] = node->children->array[i];
 	}
+	printf("populate end\n");
 }
 
 /* Recursively print children of nodes, with each child indented once from the parent */
@@ -760,6 +841,8 @@ int main(int argc, char *argv[]) {
 		filename = argv[1];
 		readfile(filename);
 	}
+
+	TRAVEL_CHAR_BUF = calloc(MAX_NUM_TRAVEL_CHARS + 1, sizeof(char));
 	/* gracefully close windows on exit of program */
 	atexit(SDL_Quit);
 
@@ -775,15 +858,22 @@ int main(int argc, char *argv[]) {
 
 		/* Handle input before rendering */
 		eventHandler(&e);
+		printf("event handler done\n");
 
+		printf("prepare scene start\n");
 		prepareScene();
+		printf("prepare scene end\n");
 
+		printf("present scene start\n");
 		presentScene();
+		printf("present scene end\n");
 
 		SDL_Delay(0);
 	}
 	write("test.txt");
 
+	if (TRAVEL_CHAR_BUF)
+		free(TRAVEL_CHAR_BUF);
 	/* delete nodes recursively, starting from root */
 	deleteNode(graph.root);
 


### PR DESCRIPTION
The Makefile fails to work because the linker flags needs to be in a specific order - after the main file arguments and CFLAGS.

Also added clean target that removes the executable with `make clean`.