### PR TITLE
Change render to only run when the visual state changes

### DIFF
--- a/dtree.c
+++ b/dtree.c
@@ -44,9 +44,9 @@ typedef struct DoublePoint DoublePoint;
 typedef struct App App;
 
 enum Mode{
-	DEFAULT,
-	EDIT,
-	TRAVEL
+    DEFAULT,
+    EDIT,
+    TRAVEL
 };
 
 struct Point {
@@ -167,7 +167,7 @@ char* getModeName(){
 }
 
 inline void requestRender() {
-	g_do_render = true;
+    g_do_render = true;
 }
 
 double clip(double num, double min, double max){
@@ -278,14 +278,14 @@ void doKeyUp(SDL_KeyboardEvent *event) {
     switch(event->keysym.sym) {
         case SDLK_ESCAPE:
             switch2Default();
-			requestRender();
+            requestRender();
             return;
         case SDLK_BACKSPACE:
             if ( graph.selected->text_len > 0 ){
                 graph.selected->text_len--;
                 graph.selected->text[graph.selected->text_len] = '\0';
             }
-			requestRender();
+            requestRender();
             return;
         case SDLK_MINUS:
             LAYER_MARGIN /= SCALE;
@@ -293,7 +293,7 @@ void doKeyUp(SDL_KeyboardEvent *event) {
             THICKNESS = (int) THICKNESS / SCALE;
             LEFT_BOUNDARY -= SIDE_MARGIN * SCALE;
             RIGHT_BOUNDARY -= SCALE;
-			requestRender();
+            requestRender();
             return;
         case SDLK_EQUALS:
             LAYER_MARGIN *= SCALE;
@@ -301,7 +301,7 @@ void doKeyUp(SDL_KeyboardEvent *event) {
             THICKNESS = (int) THICKNESS * SCALE;
             LEFT_BOUNDARY += SCALE;
             RIGHT_BOUNDARY += SCALE;
-			requestRender();
+            requestRender();
             return;
     }
 
@@ -311,37 +311,37 @@ void doKeyUp(SDL_KeyboardEvent *event) {
     switch(event->keysym.sym) {
         case SDLK_o:
             makeChild(graph.selected);
-			requestRender();
+            requestRender();
             return;
         case SDLK_d:
             removeNodeFromGraph(graph.selected);
-			requestRender();
+            requestRender();
             return;
         case SDLK_h:
             if ( graph.selected->children->num >= 1 ){
                 graph.selected = graph.selected->children->array[0];
             }
-			requestRender();
+            requestRender();
             return;
         case SDLK_l:
             if ( graph.selected->children->num >= 1 ){
                 graph.selected = graph.selected->children->array[graph.selected->children->num-1];
             }
-			requestRender();
+            requestRender();
             return;
         case SDLK_k:
             graph.selected = graph.selected->p;
-			requestRender();
+            requestRender();
             return;
         case SDLK_t:
             mode = TRAVEL;
             debug_print("boop\n");
             populateTravelText(graph.selected);
-			requestRender();
+            requestRender();
             return;
         case SDLK_e:
             mode = EDIT;
-			requestRender();
+            requestRender();
             return;
     }
     break; // end of Default bindings
@@ -349,12 +349,12 @@ void doKeyUp(SDL_KeyboardEvent *event) {
     switch(event->keysym.sym) {
         case SDLK_t:
             switch2Default();
-			requestRender();
+            requestRender();
             return;
         case SDLK_e:
             switch2Default(); // exiting travel mode requires freeing some memory
             mode = EDIT;
-			requestRender();
+            requestRender();
             return;
     }
     break; // end of Travel bindings
@@ -376,7 +376,7 @@ void eventHandler(SDL_Event *event) {
                     debug_print("edit.text[0]: %c\n", event->edit.text[0]);
                     debug_print("first: %c\n", graph.selected->text[0]);
                     debug_print("new text, len %d: %s\n", graph.selected->text_len, graph.selected->text);
-					requestRender();
+                    requestRender();
                 }
             }
             if (mode == TRAVEL){
@@ -413,7 +413,7 @@ void eventHandler(SDL_Event *event) {
                         debug_print("changing nodes\n");
                     }
                 }
-				requestRender(); // Don't know the best time for this
+                requestRender(); // Don't know the best time for this
                 debug_print("handled travel input\n");
             }
             break;
@@ -434,7 +434,7 @@ void eventHandler(SDL_Event *event) {
                 debug_print("window resized from %dx%d to %dx%d\n", app.window_size.x, app.window_size.y, w, h);
                 app.window_size.x = w;
                 app.window_size.y = h;
-				requestRender();
+                requestRender();
             }
             break;
 
@@ -1019,16 +1019,16 @@ int main(int argc, char *argv[]) {
         debug_print("event handler done\n");
 
         if (g_do_render) {
-			debug_print("prepare scene start\n");
-			prepareScene();
-			debug_print("prepare scene end\n");
+            debug_print("prepare scene start\n");
+            prepareScene();
+            debug_print("prepare scene end\n");
 
-			debug_print("present scene start\n");
-			presentScene();
-			debug_print("present scene end\n");
+            debug_print("present scene start\n");
+            presentScene();
+            debug_print("present scene end\n");
 
-			g_do_render = false;
-		}
+            g_do_render = false;
+        }
 
         SDL_Delay(0);
         debug_print("end loop\n");

--- a/dtree.c
+++ b/dtree.c
@@ -43,7 +43,11 @@ typedef struct Point Point;
 typedef struct DoublePoint DoublePoint;
 typedef struct App App;
 
-enum Mode{Default, Edit, Travel};
+enum Mode{
+	DEFAULT,
+	EDIT,
+	TRAVEL
+};
 
 struct Point {
     int x;
@@ -86,7 +90,7 @@ struct Graph {
 
 static App app;
 static Graph graph;
-static enum Mode mode = Default;
+static enum Mode mode = DEFAULT;
 
 static const char* TRAVEL_CHARS = "asdfghjl;\0";
 // radius and thickness of node ring
@@ -153,9 +157,9 @@ void switch2Default();
 
 char* getModeName(){
     switch(mode) {
-        case Default: return "DEFAULT";
-        case Edit: return "EDIT";
-        case Travel: return "TRAVEL";
+        case DEFAULT: return "DEFAULT";
+        case EDIT: return "EDIT";
+        case TRAVEL: return "TRAVEL";
         default: return NULL;
     }
 }
@@ -241,13 +245,13 @@ void initSDL() {
 
 void switch2Default(){
     debug_print("switching to default\n");
-    if ( mode == Travel ){
+    if ( mode == TRAVEL ){
         TRAVEL_NODES = freeArray (TRAVEL_NODES);
         TRAVEL_CHAR_I = 0;
         if ( TRAVEL_CHAR_BUF ) free(TRAVEL_CHAR_BUF);
         TRAVEL_CHAR_BUF = calloc(MAX_NUM_TRAVEL_CHARS, sizeof(char));
     }
-    mode = Default;
+    mode = DEFAULT;
     debug_print("switched to default %p\n", TRAVEL_NODES);
 }
 
@@ -294,7 +298,7 @@ void doKeyUp(SDL_KeyboardEvent *event) {
 
     // mode-specific key-bindings
     switch(mode) {
-    case Default:
+    case DEFAULT:
     switch(event->keysym.sym) {
         case SDLK_o:
             makeChild(graph.selected);
@@ -316,27 +320,27 @@ void doKeyUp(SDL_KeyboardEvent *event) {
             graph.selected = graph.selected->p;
             return;
         case SDLK_t:
-            mode = Travel;
+            mode = TRAVEL;
             debug_print("boop\n");
             populateTravelText(graph.selected);
             return;
         case SDLK_e:
-            mode = Edit;
+            mode = EDIT;
             return;
     }
     break; // end of Default bindings
-    case Travel:
+    case TRAVEL:
     switch(event->keysym.sym) {
         case SDLK_t:
             switch2Default();
             return;
         case SDLK_e:
             switch2Default(); // exiting travel mode requires freeing some memory
-            mode = Edit;
+            mode = EDIT;
             return;
     }
     break; // end of Travel bindings
-    case Edit: {
+    case EDIT: {
         return; // edit-mode specific key-binds don't really exist
     }
     }
@@ -346,7 +350,7 @@ void eventHandler(SDL_Event *event) {
     switch (event->type)
     {
         case SDL_TEXTINPUT:
-            if (mode == Edit){
+            if (mode == EDIT){
 
                 if ( graph.selected->text_len < MAX_TEXT_LEN ){
                     debug_print("Adding text\n");
@@ -356,7 +360,7 @@ void eventHandler(SDL_Event *event) {
                     debug_print("new text, len %d: %s\n", graph.selected->text_len, graph.selected->text);
                 }
             }
-            if (mode == Travel){
+            if (mode == TRAVEL){
                 // go to node specified by travel chars
                 debug_print("handling travel input: %d/%d\n", TRAVEL_CHAR_I, MAX_NUM_TRAVEL_CHARS);
                 // if hardcode k to be parent
@@ -507,7 +511,7 @@ void drawNode(Node* node) {
     /* render node text */
     renderMessage(node->text, message_pos, TEXTBOX_WIDTH_SCALE*node->text_len, TEXTBOX_HEIGHT, EDIT_COLOR);
     /* render travel text */
-    if ( mode == Travel ){
+    if ( mode == TRAVEL ){
         if (strlen(node->travel_text) > 0){
             // position char in center of node
             message_pos.x = (int) ((node->pos.x) * app.window_size.x)  - (int)((TEXTBOX_WIDTH_SCALE) / 2) - RADIUS;
@@ -777,7 +781,7 @@ void makeGraph(){
     graph.num_nodes = 0;
     graph.selected = graph.root;
     graph.root->p = graph.root;
-    mode = Default;
+    mode = DEFAULT;
 }
 
 


### PR DESCRIPTION
Add `requestRender()` to defer visual state changes to main loop, reducing CPU usage.