### PR TITLE
Update tree drawing algorithm

### DIFF
--- a/dtree.c
+++ b/dtree.c
@@ -134,7 +134,7 @@ Node* makeChild(Node* parent);
 void drawNode(Node* node);
 void calculate_offsets(Node* node);
 void apply_offsets(Node* node, double depth, double offset);
-int get_depth(Node* node, int depth);
+void center_on_selected(Node* node, int selected_x, int selected_y);
 void calculate_positions(Node* root, Node* selected);
 void recursively_print_positions(Node* node, int level);
 void write();
@@ -510,7 +510,6 @@ void drawRing(SDL_Renderer *surface, int n_cx, int n_cy, int radius, int thickne
         drawCircle(surface, n_cx, n_cy, radius - i, r, g, b, a);
     }
 }
-
 
 /* Renders each node, then renders it's children and draws lines to the children */
 void drawNode(Node* node) {


### PR DESCRIPTION
Tree drawing has been overhauled: `update_pos_children` and `compute_root_bounds_from_selected_and_update_pos_children` have been replaced with the functions `calculate_offsets`. `apply_offsets`, `center_on_selected`, and `calculate_positions`. The first three are recursive helper functions for the last function.
Some notes on the changes:
 - the following fields have been added to the `Node` struct for use with the tree drawing algorithm: `x_offset`, `leftmost`, `righmost` 
 - the `pos` field of a `Node` struct has been updated to signify the graphical coordinates on screen (integers). A call to `calculate_positions(node)` will re-update these coordinates for `node` and all of its ancestors, so that the selected node is centered on the screen.
 - a "unit" (i.e. `1.0`) in `calculate_offsets` signifies the separation between nodes. This gets converted to screen pixels using `RADIUS` in `apply_offsets`.
 - `calculate_positions` expects the global variable `graph.selected` to be up-to-date before it is called.
 - subtrees will be drawn to never overlap, at the cost of potentially wasting space on the screen